### PR TITLE
Add support for ~/.marx configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,22 @@ Marx can use AI model configuration directories from your home directory:
 
 These directories are mounted read-only into the Docker container during execution. This method is useful for development when you've already authenticated via the respective CLI tools.
 
+### Global Config File (`~/.marx`)
+Marx also looks for a configuration file at `~/.marx`. Any values defined here act as defaults and are only applied when the corresponding environment variable is unset. The file uses a simple `KEY=value` format and supports comments starting with `#` on their own line.
+
+Example:
+
+```
+# Default repository for GitHub operations
+MARX_REPO=acmecorp/my-app
+
+# API keys (omit or override with environment variables as needed)
+GITHUB_TOKEN=ghp_example
+OPENAI_API_KEY="sk-123"
+```
+
+This file is loaded automatically when the CLI starts. Environment variables still take precedence, allowing you to override individual values for a single run.
+
 ## Usage
 
 ```bash

--- a/marx/cli.py
+++ b/marx/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import click
 
-from marx.config import SUPPORTED_AGENTS
+from marx.config import SUPPORTED_AGENTS, load_environment_from_file
 from marx.docker_runner import DockerRunner, ReviewPrompt
 from marx.exceptions import DependencyError, MarxError
 from marx.github import GitHubClient
@@ -202,6 +202,8 @@ def main(pr: int | None, agent: str | None, repo: str | None, resume: bool) -> N
       marx --resume --pr 123                      # Reuse artifacts without rerunning agents
     """
     try:
+        load_environment_from_file()
+
         require_docker = not resume
         check_dependencies(require_docker)
 

--- a/marx/github.py
+++ b/marx/github.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 from typing import Any
 
+from marx.config import get_config_value
 from marx.exceptions import GitHubAPIError
 
 
@@ -43,7 +44,7 @@ class GitHubClient:
         """Detect repository from environment or git remote."""
         import os
 
-        repo = os.environ.get("MARX_REPO")
+        repo = os.environ.get("MARX_REPO") or get_config_value("MARX_REPO")
         if repo:
             return repo
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,50 @@
+"""Tests for Marx configuration file support."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from marx import config as marx_config
+
+
+def _write_config(tmp_path: Path, contents: str) -> Path:
+    config_path = tmp_path / ".marx"
+    config_path.write_text(contents, encoding="utf-8")
+    return config_path
+
+
+def test_load_environment_from_file_populates_environ(monkeypatch, tmp_path) -> None:
+    """Values in the config file should populate os.environ when missing."""
+
+    config_path = _write_config(
+        tmp_path,
+        """
+MARX_REPO=owner/repo
+GITHUB_TOKEN=abc123
+OPENAI_API_KEY="open-key"
+        """.strip(),
+    )
+
+    monkeypatch.delenv("MARX_REPO", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    marx_config.clear_config_cache()
+    marx_config.load_environment_from_file(config_path)
+
+    assert os.environ["MARX_REPO"] == "owner/repo"
+    assert os.environ["GITHUB_TOKEN"] == "abc123"
+    assert os.environ["OPENAI_API_KEY"] == "open-key"
+
+
+def test_load_environment_does_not_override_existing(monkeypatch, tmp_path) -> None:
+    """Environment variables should take precedence over the config file."""
+
+    config_path = _write_config(tmp_path, "GITHUB_TOKEN=from-file\n")
+    monkeypatch.setenv("GITHUB_TOKEN", "from-env")
+
+    marx_config.clear_config_cache()
+    marx_config.load_environment_from_file(config_path)
+
+    assert os.environ["GITHUB_TOKEN"] == "from-env"


### PR DESCRIPTION
## Summary
- add configuration file loading utilities and load them on CLI startup
- allow GitHub repository detection to fall back to MARX_REPO from ~/.marx
- document the ~/.marx file format and add regression tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912eb298c4c8332801fa83812fd860a)