### PR TITLE
Add early validation for repository and PR existence

### DIFF
--- a/marx/cli.py
+++ b/marx/cli.py
@@ -249,12 +249,17 @@ def main(pr: int | None, agents: str | None, repo: str | None, resume: bool) -> 
         github_client = GitHubClient(repo=repo)
         print_info(f"Repository: {github_client.repo}")
 
+        print_header("🔍 Validating repository and PR...")
+        github_client.validate_repository()
+        print_success(f"Repository {github_client.repo} is accessible")
+
         if not os.environ.get("GITHUB_TOKEN"):
             print_warning("GITHUB_TOKEN environment variable is not set")
             print_info("The AI agents may not be able to access GitHub API inside the container")
 
         if pr:
             print_info(f"Using PR #{pr} from command line")
+            github_client.validate_pr(pr)
             pr_data = github_client.get_pr(pr)
             pr_number = pr_data["number"]
             branch_name = pr_data["headRefName"]

--- a/marx/github.py
+++ b/marx/github.py
@@ -93,6 +93,28 @@ class GitHubClient:
 
         return None
 
+    def validate_repository(self) -> None:
+        """Validate that the repository exists and is accessible."""
+        try:
+            self._run_gh_command(
+                ["repo", "view", self.repo, "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
+            )
+        except GitHubAPIError as e:
+            raise GitHubAPIError(
+                f"Repository '{self.repo}' not found or not accessible. "
+                "Please check the repository name and your GitHub permissions."
+            ) from e
+
+    def validate_pr(self, pr_number: int) -> None:
+        """Validate that the PR exists and is accessible."""
+        try:
+            self._run_gh_command(["pr", "view", str(pr_number), "--repo", self.repo])
+        except GitHubAPIError:
+            raise GitHubAPIError(
+                f"PR #{pr_number} not found in repository '{self.repo}'. "
+                "Please check the PR number."
+            ) from None
+
     def get_current_user(self) -> str:
         """Get the current GitHub username."""
         try:


### PR DESCRIPTION
## Summary
- Validate repository exists and is accessible via GitHub API
- Validate PR exists before running expensive operations
- Provide clear, user-friendly error messages for invalid inputs

## Changes
This PR adds early validation to prevent wasted time and resources when invalid repository or PR numbers are provided:

1. **New validation methods in `marx/github.py`:**
   - `validate_repository()`: Checks if the repository exists and is accessible
   - `validate_pr(pr_number)`: Checks if the PR exists in the specified repository

2. **Updated `marx/cli.py`:**
   - Added validation checkpoint after `GitHubClient` creation
   - Repository validation happens immediately after client initialization
   - PR validation happens when `--pr` flag is provided
   - Both validations occur **before** expensive operations like Docker image building

3. **Improved error messages:**
   - Invalid repo: `Repository 'owner/repo' not found or not accessible. Please check the repository name and your GitHub permissions.`
   - Invalid PR: `PR #123 not found in repository 'owner/repo'. Please check the PR number.`

## Benefits
- **Fail fast:** Catch configuration errors immediately instead of after building Docker images
- **Better UX:** Clear, actionable error messages help users quickly identify and fix issues
- **Resource efficiency:** Avoid wasting time and resources on invalid inputs

## Testing
- ✅ Tested with invalid repository → fails fast with clear error
- ✅ Tested with invalid PR → fails fast with clear error
- ✅ Tested with valid repo and PR → passes validation and proceeds normally
- ✅ All 30 unit tests passing
- ✅ All linting and type checks passing

## Example Output

### Invalid repository:
```
ℹ️  Repository: invalid/nonexistent-repo-12345
🔍 Validating repository and PR...
❌ Repository 'invalid/nonexistent-repo-12345' not found or not accessible. 
Please check the repository name and your GitHub permissions.
```

### Invalid PR:
```
ℹ️  Repository: forketyfork/marx
🔍 Validating repository and PR...
✅ Repository forketyfork/marx is accessible
ℹ️  Using PR #999999 from command line
❌ PR #999999 not found in repository 'forketyfork/marx'. Please check the PR number.
```

### Valid inputs:
```
ℹ️  Repository: forketyfork/marx
🔍 Validating repository and PR...
✅ Repository forketyfork/marx is accessible
ℹ️  Using PR #10 from command line
✅ Found PR #10 with branch: fix/remove-shellcheck-and-ui-bug
✅ PR head commit: 43d28014
```